### PR TITLE
fix(sandbox): preserve slashes in branch names as hyphens

### DIFF
--- a/src/core/sandbox/git.ts
+++ b/src/core/sandbox/git.ts
@@ -54,6 +54,9 @@ export async function getCurrentBranch(): Promise<string | null> {
 }
 
 export function sanitizeBranchName(ref: string): string {
-  const name = ref.includes("/") ? ref.split("/").pop()! : ref;
-  return name.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/^-+|-+$/g, "");
+  return ref
+    .replace(/\/+/g, "-")
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
 }


### PR DESCRIPTION
## Summary

- `sanitizeBranchName` previously dropped everything before the last `/` in a branch name (e.g. `feature/auth` → `auth`), which caused collisions between branches like `feature/auth` and `bugfix/auth`
- Now slashes and other unsafe characters are converted to hyphens, preserving the full branch name (e.g. `feature/auth` → `feature-auth`, `abhi/test$12#44` → `abhi-test-12-44`)
- Consecutive hyphens are collapsed and leading/trailing hyphens are trimmed